### PR TITLE
Configure with self

### DIFF
--- a/halo2_proofs/Cargo.toml
+++ b/halo2_proofs/Cargo.toml
@@ -82,6 +82,7 @@ gadget-traces = ["backtrace"]
 sanity-checks = []
 batch = ["rand_core/getrandom"]
 floor-planner-v1-legacy-pdqsort = ["halo2_legacy_pdqsort"]
+circuit-self = []
 
 # In-development features
 # See https://zcash.github.io/halo2/dev/features.html

--- a/halo2_proofs/src/circuit.rs
+++ b/halo2_proofs/src/circuit.rs
@@ -49,7 +49,7 @@ pub trait Chip<F: Field>: Sized {
 }
 
 /// Index of a region in a layouter
-#[derive(Clone, Copy, Debug)]
+#[derive(Clone, Copy, Debug, PartialEq)]
 pub struct RegionIndex(usize);
 
 impl From<usize> for RegionIndex {
@@ -85,7 +85,7 @@ impl std::ops::Deref for RegionStart {
 }
 
 /// A pointer to a cell within a circuit.
-#[derive(Clone, Copy, Debug)]
+#[derive(Clone, Copy, Debug, PartialEq)]
 pub struct Cell {
     /// Identifies the region in which this cell resides.
     region_index: RegionIndex,

--- a/halo2_proofs/src/circuit/value.rs
+++ b/halo2_proofs/src/circuit/value.rs
@@ -12,7 +12,7 @@ use crate::plonk::{Assigned, Error};
 ///   helps to ensure that unwitnessed values correctly propagate.
 /// - It provides pass-through implementations of common traits such as `Add` and `Mul`,
 ///   for improved usability.
-#[derive(Clone, Copy, Debug)]
+#[derive(Clone, Copy, Debug, PartialEq)]
 pub struct Value<V> {
     inner: Option<V>,
 }

--- a/halo2_proofs/src/dev.rs
+++ b/halo2_proofs/src/dev.rs
@@ -490,7 +490,12 @@ impl<F: Field + Ord> MockProver<F> {
         let n = 1 << k;
 
         let mut cs = ConstraintSystem::default();
+
+        #[cfg(feature = "circuit-self")]
+        let config = circuit.configure_with_self(&mut cs);
+        #[cfg(not(feature = "circuit-self"))]
         let config = ConcreteCircuit::configure(&mut cs);
+
         let cs = cs;
 
         if n < cs.minimum_rows() {

--- a/halo2_proofs/src/dev/cost.rs
+++ b/halo2_proofs/src/dev/cost.rs
@@ -261,7 +261,12 @@ impl<G: PrimeGroup, ConcreteCircuit: Circuit<G::Scalar>> CircuitCost<G, Concrete
     pub fn measure(k: u32, circuit: &ConcreteCircuit) -> Self {
         // Collect the layout details.
         let mut cs = ConstraintSystem::default();
+
+        #[cfg(feature = "circuit-self")]
+        let config = circuit.configure_with_self(&mut cs);
+        #[cfg(not(feature = "circuit-self"))]
         let config = ConcreteCircuit::configure(&mut cs);
+
         let mut layout = Layout::new(k, 1 << k, cs.num_selectors);
         ConcreteCircuit::FloorPlanner::synthesize(
             &mut layout,

--- a/halo2_proofs/src/dev/graph.rs
+++ b/halo2_proofs/src/dev/graph.rs
@@ -22,7 +22,12 @@ pub fn circuit_dot_graph<F: Field, ConcreteCircuit: Circuit<F>>(
 ) -> String {
     // Collect the graph details.
     let mut cs = ConstraintSystem::default();
+
+    #[cfg(feature = "circuit-self")]
+    let config = circuit.configure_with_self(&mut cs, params);
+    #[cfg(not(feature = "circuit-self"))]
     let config = ConcreteCircuit::configure(&mut cs);
+
     let mut graph = Graph::default();
     ConcreteCircuit::FloorPlanner::synthesize(&mut graph, circuit, config, cs.constants).unwrap();
 

--- a/halo2_proofs/src/dev/graph.rs
+++ b/halo2_proofs/src/dev/graph.rs
@@ -24,7 +24,7 @@ pub fn circuit_dot_graph<F: Field, ConcreteCircuit: Circuit<F>>(
     let mut cs = ConstraintSystem::default();
 
     #[cfg(feature = "circuit-self")]
-    let config = circuit.configure_with_self(&mut cs, params);
+    let config = circuit.configure_with_self(&mut cs);
     #[cfg(not(feature = "circuit-self"))]
     let config = ConcreteCircuit::configure(&mut cs);
 

--- a/halo2_proofs/src/dev/graph/layout.rs
+++ b/halo2_proofs/src/dev/graph/layout.rs
@@ -94,7 +94,12 @@ impl CircuitLayout {
         let n = 1 << k;
         // Collect the layout details.
         let mut cs = ConstraintSystem::default();
+
+        #[cfg(feature = "circuit-self")]
+        let config = circuit.configure_with_self(&mut cs, params);
+        #[cfg(not(feature = "circuit-self"))]
         let config = ConcreteCircuit::configure(&mut cs);
+
         let mut layout = Layout::new(k, n, cs.num_selectors);
         ConcreteCircuit::FloorPlanner::synthesize(
             &mut layout,

--- a/halo2_proofs/src/dev/graph/layout.rs
+++ b/halo2_proofs/src/dev/graph/layout.rs
@@ -96,7 +96,7 @@ impl CircuitLayout {
         let mut cs = ConstraintSystem::default();
 
         #[cfg(feature = "circuit-self")]
-        let config = circuit.configure_with_self(&mut cs, params);
+        let config = circuit.configure_with_self(&mut cs);
         #[cfg(not(feature = "circuit-self"))]
         let config = ConcreteCircuit::configure(&mut cs);
 

--- a/halo2_proofs/src/dev/tfp.rs
+++ b/halo2_proofs/src/dev/tfp.rs
@@ -131,6 +131,10 @@ impl<'c, F: Field, C: Circuit<F>> Circuit<F> for TracingCircuit<'c, F, C> {
         C::configure(meta)
     }
 
+    fn configure_with_self(&self, meta: &mut ConstraintSystem<F>) -> Self::Config {
+        self.inner_ref().configure_with_self(meta)
+    }
+
     fn synthesize(&self, config: Self::Config, layouter: impl Layouter<F>) -> Result<(), Error> {
         let _span = debug_span!("synthesize").entered();
         self.inner_ref()

--- a/halo2_proofs/src/plonk.rs
+++ b/halo2_proofs/src/plonk.rs
@@ -9,9 +9,10 @@ use blake2b_simd::Params as Blake2bParams;
 use group::ff::{Field, FromUniformBytes, PrimeField};
 
 use crate::arithmetic::CurveAffine;
+use crate::helpers::CurveRead;
 use crate::poly::{
-    Coeff, EvaluationDomain, ExtendedLagrangeCoeff, LagrangeCoeff, PinnedEvaluationDomain,
-    Polynomial,
+    commitment::Params, Coeff, EvaluationDomain, ExtendedLagrangeCoeff, LagrangeCoeff,
+    PinnedEvaluationDomain, Polynomial,
 };
 use crate::transcript::{ChallengeScalar, EncodedChallenge, Transcript};
 
@@ -47,17 +48,85 @@ pub struct VerifyingKey<C: CurveAffine> {
     cs_degree: usize,
     /// The representative of this `VerifyingKey` in transcripts.
     transcript_repr: C::Scalar,
+    selectors: Vec<Vec<bool>>,
 }
 
 impl<C: CurveAffine> VerifyingKey<C>
 where
     C::Scalar: FromUniformBytes<64>,
 {
+    /// Writes a verifying key to a buffer.
+    pub fn write<W: io::Write>(&self, writer: &mut W) -> io::Result<()> {
+        writer.write_all(&(self.fixed_commitments.len() as u32).to_be_bytes())?;
+        for commitment in &self.fixed_commitments {
+            writer.write_all(commitment.to_bytes().as_ref())?;
+        }
+        self.permutation.write(writer)?;
+
+        // write self.selectors
+        for selector in &self.selectors {
+            let mut selector_bytes = vec![0u8; selector.len() / 8 + 1];
+            for (i, selector_idx) in selector.iter().enumerate() {
+                let byte_index = i / 8;
+                let bit_index = i % 8;
+                selector_bytes[byte_index] |= (*selector_idx as u8) << bit_index;
+            }
+            writer.write_all(&selector_bytes)?;
+        }
+
+        Ok(())
+    }
+
+    /// Reads a verification key from a buffer.
+    pub fn read<R: io::Read, ConcreteCircuit: Circuit<C::Scalar>>(
+        reader: &mut R,
+        params: &Params<C>,
+    ) -> io::Result<Self> {
+        let (domain, cs, _) = keygen::create_domain::<C, ConcreteCircuit>(params);
+        let mut num_fixed_columns_be_bytes = [0u8; 4];
+        reader.read_exact(&mut num_fixed_columns_be_bytes)?;
+        let num_fixed_columns = u32::from_be_bytes(num_fixed_columns_be_bytes);
+
+        let fixed_commitments: Vec<_> = (0..num_fixed_columns)
+            .map(|_| C::read(reader))
+            .collect::<Result<_, _>>()?;
+
+        let permutation = permutation::VerifyingKey::read(reader, &cs.permutation)?;
+
+        // read selectors
+        let selectors: Vec<Vec<bool>> = vec![vec![false; params.n as usize]; cs.num_selectors]
+            .into_iter()
+            .map(|mut selector| {
+                let mut selector_bytes = vec![0u8; selector.len() / 8 + 1];
+                reader
+                    .read_exact(&mut selector_bytes)
+                    .expect("unable to read selector bytes");
+                for (i, selector_idx) in selector.iter_mut().enumerate() {
+                    let byte_index = i / 8;
+                    let bit_index = i % 8;
+                    *selector_idx = (selector_bytes[byte_index] >> bit_index) & 1 == 1;
+                }
+                Ok(selector)
+            })
+            .collect::<Result<Vec<Vec<bool>>, &str>>()
+            .unwrap();
+        let (cs, _) = cs.compress_selectors(selectors.clone());
+
+        Ok(Self::from_parts(
+            domain,
+            fixed_commitments,
+            permutation,
+            cs,
+            selectors,
+        ))
+    }
+
     fn from_parts(
         domain: EvaluationDomain<C::Scalar>,
         fixed_commitments: Vec<C>,
         permutation: permutation::VerifyingKey<C>,
         cs: ConstraintSystem<C::Scalar>,
+        selectors: Vec<Vec<bool>>,
     ) -> Self {
         // Compute cached values.
         let cs_degree = cs.degree();
@@ -70,6 +139,7 @@ where
             cs_degree,
             // Temporary, this is not pinned.
             transcript_repr: C::Scalar::ZERO,
+            selectors,
         };
 
         let mut hasher = Blake2bParams::new()

--- a/halo2_proofs/src/plonk/circuit.rs
+++ b/halo2_proofs/src/plonk/circuit.rs
@@ -478,6 +478,11 @@ pub trait Circuit<F: Field> {
     /// arrangement, column arrangement, etc.
     fn configure(meta: &mut ConstraintSystem<F>) -> Self::Config;
 
+    /// Same as configure but takes self to take additional runtime data.
+    fn configure_with_self(&self, meta: &mut ConstraintSystem<F>) -> Self::Config {
+        Self::configure(meta)
+    }
+
     /// Given the provided `cs`, synthesize the circuit. The concrete type of
     /// the caller will be different depending on the context, and they may or
     /// may not expect to have a witness present.

--- a/halo2_proofs/src/plonk/circuit.rs
+++ b/halo2_proofs/src/plonk/circuit.rs
@@ -479,6 +479,7 @@ pub trait Circuit<F: Field> {
     fn configure(meta: &mut ConstraintSystem<F>) -> Self::Config;
 
     /// Same as configure but takes self to take additional runtime data.
+    /// Credit: https://github.com/privacy-scaling-explorations/halo2/pull/168
     fn configure_with_self(&self, meta: &mut ConstraintSystem<F>) -> Self::Config {
         Self::configure(meta)
     }

--- a/halo2_proofs/src/plonk/keygen.rs
+++ b/halo2_proofs/src/plonk/keygen.rs
@@ -24,6 +24,7 @@ use crate::{
 
 pub(crate) fn create_domain<C, ConcreteCircuit>(
     params: &Params<C>,
+    #[cfg(feature = "circuit-self")] circuit: &ConcreteCircuit,
 ) -> (
     EvaluationDomain<C::Scalar>,
     ConstraintSystem<C::Scalar>,
@@ -34,6 +35,10 @@ where
     ConcreteCircuit: Circuit<C::Scalar>,
 {
     let mut cs = ConstraintSystem::default();
+
+    #[cfg(feature = "circuit-self")]
+    let config = circuit.configure_with_self(&mut cs);
+    #[cfg(not(feature = "circuit-self"))]
     let config = ConcreteCircuit::configure(&mut cs);
 
     let degree = cs.degree();
@@ -195,7 +200,11 @@ where
     C::Scalar: FromUniformBytes<64>,
     ConcreteCircuit: Circuit<C::Scalar>,
 {
-    let (domain, cs, config) = create_domain::<C, ConcreteCircuit>(params);
+    let (domain, cs, config) = create_domain::<C, ConcreteCircuit>(
+        params,
+        #[cfg(feature = "circuit-self")]
+        circuit,
+    );
 
     if (params.n as usize) < cs.minimum_rows() {
         return Err(Error::not_enough_rows_available(params.k));
@@ -255,6 +264,10 @@ where
     ConcreteCircuit: Circuit<C::Scalar>,
 {
     let mut cs = ConstraintSystem::default();
+
+    #[cfg(feature = "circuit-self")]
+    let config = circuit.configure_with_self(&mut cs);
+    #[cfg(not(feature = "circuit-self"))]
     let config = ConcreteCircuit::configure(&mut cs);
 
     let cs = cs;

--- a/halo2_proofs/src/plonk/keygen.rs
+++ b/halo2_proofs/src/plonk/keygen.rs
@@ -219,7 +219,7 @@ where
     )?;
 
     let mut fixed = batch_invert_assigned(assembly.fixed);
-    let (cs, selector_polys) = cs.compress_selectors(assembly.selectors);
+    let (cs, selector_polys) = cs.compress_selectors(assembly.selectors.clone());
     fixed.extend(
         selector_polys
             .into_iter()
@@ -240,6 +240,7 @@ where
         fixed_commitments,
         permutation_vk,
         cs,
+        assembly.selectors,
     ))
 }
 

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,2 +1,2 @@
 [toolchain]
-channel = "1.60.0"
+channel = "nightly"


### PR DESCRIPTION
Took the `self` approach (instead of params) because:
1. it's a non breaking change for the circuit code
1. the configuration data will come from `self` for the `ZkCircuit` case I think

So it's all nice and non invasive.